### PR TITLE
Implement flushing of long-term agent memory

### DIFF
--- a/src/agents/agent.rs
+++ b/src/agents/agent.rs
@@ -51,6 +51,12 @@ impl BaseAgent {
         }
     }
 
+    pub async fn flush_to_global_long(&self, ctx: &Context) {
+        for (k, v) in self.ctx.mem_long.iter() {
+            ctx.mem_long.set(k, v).await;
+        }
+    }
+
     pub fn get_short(&self, key: &str) -> Option<String> {
         Some(self.ctx.get_mem("short", key))
     }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -114,6 +114,7 @@ pub async fn chat(Json(payload): Json<ChatPayload>) -> axum::Json<String> {
     let mut ctx = Context::new();
     let response = agent.handle(&payload.message, &mut ctx).await;
     agent.flush_to_global_short(&mut ctx);
+    agent.flush_to_global_long(&ctx).await;
 
     axum::Json(response.unwrap_or_else(|| "No response.".to_string()))
 }
@@ -168,6 +169,7 @@ pub async fn sentience_run_handler(
     let mut ctx = Context::new();
     let output = agent.handle(&payload.code, &mut ctx).await;
     agent.flush_to_global_short(&mut ctx);
+    agent.flush_to_global_long(&ctx).await;
 
     axum::Json(SentienceResponse {
         output: output.unwrap_or_else(|| "".to_string()),


### PR DESCRIPTION
## Summary
- support pushing agent long-term memory to the global context
- call the new flush function after agent executions

## Testing
- `cargo test` *(fails: failed to fetch `sentience` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68461304ea28833182c9f7787dbe348f